### PR TITLE
Remove chunk processing

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -24,15 +24,6 @@ import {
 
 let pluginName = `GraphQL Codegen`;
 
-function chunk<T>(arr: T[], size: number) {
-  let chunks: T[][] = [];
-  let i = 0;
-  while (i < arr.length) {
-    chunks.push(arr.slice(i, (i += size)));
-  }
-  return chunks;
-}
-
 /**
  * NOTE:
  * Insomnia will generate new ids for any resource with an id that matches this regex: /__\w+_\d+__/g;
@@ -299,18 +290,14 @@ async function importToCurrentWorkspace(
     });
   }
 
-  let resources = [
-    ...subscriptionsRequestGroup,
-    ...queriesRequestGroup,
-    ...mutationsRequestGroup,
-    workspace
+  let requestGroups = [
+    subscriptionsRequestGroup,
+    queriesRequestGroup,
+    mutationsRequestGroup,
   ];
 
-  let resourcesChunks = chunk(resources, 30);
-
-  for (let resourcesChunk of resourcesChunks) {
-    debugger;
-    await importResources(resourcesChunk);
+  for (let requestGroup of requestGroups) {
+    await importResources(requestGroup);
   }
 }
 


### PR DESCRIPTION
In case `chunk` is called

e.g.

- Chunk1
<img width="260" alt="image" src="https://user-images.githubusercontent.com/3423547/188241270-a37274ed-9e99-489c-ac00-2383cc32bd84.png">

- Chunk2
<img width="265" alt="image" src="https://user-images.githubusercontent.com/3423547/188241343-aa03e197-a1f9-4a0b-b462-fdc3bdf43ca8.png">

`__INSOMNIA_48__` and `__INSOMNIA_49__` are not created.

Fix the behavior.
